### PR TITLE
Force move of gclient_env

### DIFF
--- a/alice-env.sh
+++ b/alice-env.sh
@@ -332,7 +332,7 @@ function AliAliEnPatchGclientEnv() (
       [[ $line != '' ]] && echo "$line"
 
     done < <( cat "$envFile" ) > "${envFile}.0"
-    \mv "${envFile}.0" "$envFile"
+    \mv -f "${envFile}.0" "$envFile"
 
   fi
 )


### PR DESCRIPTION
This avoids annoying prompt to people having alias mv='mv -i'