### PR TITLE
Fix of the parsing of the argument coming after -n.

### DIFF
--- a/alice-env.sh
+++ b/alice-env.sh
@@ -832,7 +832,7 @@ function AliMain() {
         OPT_NONINTERACTIVE=1
         nAliTuple=$(( $2 ))
         [[ $nAliTuple == 0 ]] && unset nAliTuple
-        shift
+        [[ $2 =~ ^[0-9]+$ ]] && shift
       ;;
       -m)
         OPT_NONINTERACTIVE=1


### PR DESCRIPTION
The first argument after -n was skipped by default, for instance `ali -n -q` behaved differently with respect to `ali -q -n`. With this modification the argument after -n is skipped only if it is a number.